### PR TITLE
Fixed broken links in Authentication doc

### DIFF
--- a/content/docs/authentication/index.md
+++ b/content/docs/authentication/index.md
@@ -31,7 +31,7 @@ If you want a **user token**, you must use one of these flows:
 * **[Web flow (client-side)](/docs/authentication/flows/web/#client-side-flow)** - use this if you're building an application without a central server, like a mobile app or a client-side Javascript app. (The OAuth 2.0 internet-draft calls this the [Implicit Grant Flow](http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.2).)
 * **[Password flow](/docs/authentication/flows/password/)** - use this if you're building a native application (or an application where it is difficult to use a web browser) and want to avoid implementing a web-based authentication flow. This flow requires special permission to use and comes with a bunch of extra rules and requirements to protect user security.
 
-If you're only interested in obtaining a **client token** (sometimes called an "App token"), you can use the **[app access token flow](/docs/authentication/flows/app_access_token)**. (The OAuth 2.0 internet-draft calls this this [Client Credentials Grant](http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.4).)
+If you're only interested in obtaining a **client token** (sometimes called an "App token"), you can use the **[app access token flow](/docs/authentication/flows/app-access-token)**. (The OAuth 2.0 internet-draft calls this this [Client Credentials Grant](http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.4).)
 
 We also intend to provide a SDK you can embed into your mobile applications to provide seamless authentication with App.net to your application's users.
 
@@ -104,5 +104,5 @@ When making a call to one of our API resources, there are three ways to include 
 ## How can I authenticate between App.net apps?
 
 We call this Identity Delegation. The detailed [Identity Delegation
-specification](identity_delegation/) has its own page.
+specification](identity-delegation/) has its own page.
 


### PR DESCRIPTION
The links to the app access token flow and identity delegation are currently broken on http://developers.app.net/docs/authentication/
