### PR TITLE
Fix inclusion of File endpoints in overall listing of endpoints

### DIFF
--- a/content/docs/resources/index.md
+++ b/content/docs/resources/index.md
@@ -38,7 +38,7 @@ Please use https://alpha-api.app.net/ to access the APIs.
 
 ## File
 
-<%= render 'partials/endpoints/filter' %>
+<%= render 'partials/endpoints/file' %>
 
 ## Stream
 


### PR DESCRIPTION
A tiny typo caused the Filter endpoints being included instead.

See http://developers.app.net/docs/resources/#file for the issue.
